### PR TITLE
Fix CONFIGS visibility issue in single_download function

### DIFF
--- a/opendv/scripts/youtube_download.py
+++ b/opendv/scripts/youtube_download.py
@@ -18,7 +18,9 @@ from utils.download import youtuber_formatize, POSSIBLE_EXTS, get_video_with_met
 
 CONFIGS = dict()
 
-def single_download(vid_info):
+def single_download(args):
+    vid_info, CONFIGS = args
+
     url = vid_info["link"]
     filename = vid_info["videoid"]
     folder = youtuber_formatize(vid_info["youtuber"])
@@ -54,7 +56,7 @@ def multiple_download(video_list, configs):
     finished = 0
     with Pool(configs.num_workers) as p:
         current_time = time.perf_counter()
-        for _ in tqdm(p.imap(single_download, video_list), total=video_count):
+        for _ in tqdm(p.imap(single_download, [(vid_info, CONFIGS) for vid_info in video_list]), total=video_count):
             finished += 1
             working_time = time.perf_counter() - current_time
             eta = working_time / finished * (video_count - finished)
@@ -102,7 +104,7 @@ if __name__ == '__main__':
     parser.add_argument("--config", type=str, default="configs/download.json", help="Path to the config file. should be a `json` file.")
     parser.add_argument("--mini", action="store_true", default=False, help="Download mini dataset only.")
     args = parser.parse_args()
-    
+
     configs = EasyDict(json.load(open(args.config, "r")))
     with open(configs.exception_file, "w") as f:
         f.write("")


### PR DESCRIPTION
When running youtube_download.py, I encountered an error indicating that the CONFIGS variable has no root field. Upon debugging, I discovered that the global CONFIGS variable becomes an empty dictionary when entering the single_download function.

To resolve this, I passed CONFIGS as an argument to the single_download function, addressing the visibility issue with the global variable. The changes include:
	1.	Modified the single_download function to accept args as an argument and unpack it into video_info and CONFIGS, which resolves the error when calling CONFIGS.root().
	2.	Updated the multiple_download function to pass both video_info and CONFIGS in every iteration through video_list ( [(vid_info, CONFIGS) for vid_info in video_list]) ).